### PR TITLE
[js] Print the LCOV report in the browser console

### DIFF
--- a/src/instrument/coverage/reporter/LcovCoverageReporter.hx
+++ b/src/instrument/coverage/reporter/LcovCoverageReporter.hx
@@ -134,7 +134,7 @@ class LcovCoverageReporter extends FileBaseReporter implements ICoverageReporter
 		text.add("\n");
 
 		text.add("end_of_record\n\n");
-		appendCoverageFile(text.toString());
+		output(text.toString());
 	}
 
 	function makeBranchCoverage(types:Array<TypeInfo>):String {


### PR DESCRIPTION
Currently, the LCOV report is never output in browsers. This makes it impossible to collect the coverage when testing code in Puppeteer/Playwright/Whatever.